### PR TITLE
linux-6.18: optional i915 patch enabling interlaced modes on Intel gen9

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The provided kernel patches enable the 15kHz video output with additional featur
 | | 06_linux_switchres_kms_drm_modesetting.patch                 | KMS modesetting manipulation for X-less switchres KMS usage, groovyarcade kms enabler                      |
 |+| 07_linux_15khz_fix_ddc.patch                                 | since kernel 6.7, fix kernel oops when probing DDC and no adapter is connected                             |
 |+| 08_linux_15khz_interlace_force_even.patch                    | since kernel 6.19, force even field on interlaced picture for amd DCN1                                     |
+| | 09_linux_15khz_i915_gen9_interlace.patch                     | optional, for i915 driver, enable interlaced mode on Intel gen9 (DISPLAY_VER 9) via i915.no_ytiled_scanout=1 |
 
 ### KERNEL COMPATIBILITY
 

--- a/linux-6.18/09_linux_15khz_i915_gen9_interlace.patch
+++ b/linux-6.18/09_linux_15khz_i915_gen9_interlace.patch
@@ -1,0 +1,62 @@
+Index: linux-6.18/drivers/gpu/drm/i915/display/intel_display_params.h
+===================================================================
+--- linux-6.18.orig/drivers/gpu/drm/i915/display/intel_display_params.h
++++ linux-6.18/drivers/gpu/drm/i915/display/intel_display_params.h
+@@ -50,6 +50,7 @@
+ 	param(bool, psr_safest_params, false, 0400) \
+ 	param(bool, enable_psr2_sel_fetch, true, 0400) \
+ 	param(int, enable_dmc_wl, -1, 0400) \
++	param(bool, no_ytiled_scanout, false, 0400) \
+ 
+ #define MEMBER(T, member, ...) T member;
+ struct intel_display_params {
+Index: linux-6.18/drivers/gpu/drm/i915/display/intel_display_params.c
+===================================================================
+--- linux-6.18.orig/drivers/gpu/drm/i915/display/intel_display_params.c
++++ linux-6.18/drivers/gpu/drm/i915/display/intel_display_params.c
+@@ -139,6 +139,13 @@
+ 	"(-1=use per-chip default, 0=disabled, 1=enabled, 2=match any register, 3=always locked) "
+ 	"Default: -1");
+ 
++intel_display_param_named_unsafe(no_ytiled_scanout, bool, 0400,
++	"Advertise only LINEAR/X_TILED scanout modifiers on DISPLAY_VER 9. "
++	"Y/Yf tiled scanout is rejected in IF-ID interlace mode, and the "
++	"modifier is chosen at buffer allocation time, so this is what makes "
++	"interlaced (480i) modes usable on gen9. No effect on other platforms. "
++	"Default: false");
++
+ __maybe_unused
+ static void _param_print_bool(struct drm_printer *p, const char *driver_name,
+ 			      const char *name, bool val)
+Index: linux-6.18/drivers/gpu/drm/i915/display/intel_fb.c
+===================================================================
+--- linux-6.18.orig/drivers/gpu/drm/i915/display/intel_fb.c
++++ linux-6.18/drivers/gpu/drm/i915/display/intel_fb.c
+@@ -556,6 +556,27 @@
+ 		return false;
+ 
+ 	/*
++	 * The display engine rejects Y/Yf tiled scanout (and the CCS variants,
++	 * which are Y based) in IF-ID interlace mode, see the "Y/Yf tiling not
++	 * supported in IF-ID mode" check in skl_plane_check(). Userspace picks
++	 * a modifier when it allocates the buffer, long before any interlaced
++	 * mode is set, and gen9 Mesa/glamor prefers Y tiling -- so an
++	 * interlaced modeset then fails the atomic check with -EINVAL and there
++	 * is nothing left to fall back to.
++	 *
++	 * Advertising only LINEAR/X_TILED makes the scanout buffer interlace
++	 * capable from the start. It also costs Y tiling and render compression
++	 * for everything else on this platform, which is why it is opt-in
++	 * rather than the default: it is only worth it if the machine actually
++	 * drives an interlaced display, such as a 15kHz CRT.
++	 */
++	if (display->params.no_ytiled_scanout &&
++	    DISPLAY_VER(display) == 9 &&
++	    md->modifier != DRM_FORMAT_MOD_LINEAR &&
++	    md->modifier != I915_FORMAT_MOD_X_TILED)
++		return false;
++
++	/*
+ 	 * Separate AuxCCS and Flat CCS modifiers to be run only on platforms
+ 	 * where supported.
+ 	 */


### PR DESCRIPTION
This adds the missing Intel piece: interlaced (480i) modes on gen9 integrated
graphics, which currently cannot work at all.

## The problem

Interlace support is not missing. `intel_dp.c` already sets `interlace_allowed`
for `DISPLAY_VER < 12`. What fails is the framebuffer modifier.

The display engine rejects Y/Yf tiled scanout while a pipe runs in IF-ID
interlace mode — see the "Y/Yf tiling not supported in IF-ID mode" check in
`skl_plane_check()`. Userspace picks the modifier when it *allocates* the
buffer, long before any mode is set, and Mesa/glamor prefers Y tiling on gen9.
So every interlaced modeset fails the atomic check with -EINVAL, surfacing as
the unhelpful:

```
xrandr: Configure crtc 0 failed
(EE) modeset(0): failed to set mode: No such file or directory
```

## The patch

Because the modifier is chosen before the driver can know whether the buffer
will ever be scanned out interlaced, this cannot be decided per-mode. The only
thing the driver can do is not offer the modifiers that interlace cannot use.

Doing that unconditionally would cost every gen9 machine Y tiling and render
compression to serve a feature almost none of them want, so it is behind a
module parameter, off by default:

```
i915.no_ytiled_scanout=1
```

With it set, gen9 advertises only LINEAR and X_TILED for scanout. X tiling is a
first class scanout format here, so glamor acceleration keeps working — unlike
`Option "AccelMethod" "none"`, which produces linear buffers but has no swrast
fallback on builds without `swrast_dri.so`.

No effect on any other display generation, and none at all unless the parameter
is set.

## Testing

**This patch as submitted:** `i915.ko` built from vanilla 6.18.16 + patch 09 and
nothing else, loaded into Batocera 43.1's 6.18.16 kernel, which carries this
folder's 15 kHz patches. HP ProDesk 400 G2 Mini, HD Graphics 530 (Skylake,
`DISPLAY_VER` 9), VGA flex port into SCART on a Sony Trinitron. Without the
parameter, every interlaced modeset is rejected with `Y/Yf tiling not supported
in IF-ID mode`; with `i915.no_ytiled_scanout=1`, real 640x454 and 720x480
interlaced at 15.734 kHz, confirmed from debugfs and on the set. Details in the
comment below.

**Earlier, unconditional revision** of the same change: also HP ProDesk 400 G5
Mini with UHD Graphics 630 (Coffee Lake), where Switchres generated and set
interlaced modes normally, e.g. `SR-1_1280x480@59.94i` at 15.67 kHz.

Only tested against 6.18, so I have only added it to `linux-6.18`. It also
applies cleanly to 6.18.45 and 7.2.5, but I have not tested those.

Written up in more detail, with the measurements, at
https://github.com/amxcs/batocera-crt-15khz-intel
